### PR TITLE
Add remote next piece display

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,12 @@
   <div class="board">
     <div id="score">0</div>
     <canvas id="tetris" width="240" height="400"></canvas>
-    <div id="next-container"></div>
+    <div id="next-container" class="next-container"></div>
   </div>
   <div class="board">
     <div id="remote-score">0</div>
     <canvas id="remote-tetris" width="240" height="400"></canvas>
+    <div id="remote-next-container" class="next-container"></div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
   <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -13,13 +13,26 @@ const nextContainer = document.getElementById('next-container');
 const nextContexts = [];
 for (let i = 0; i < 5; ++i) {
   const c = document.createElement('canvas');
-  c.width = 80;
-  c.height = 80;
+  c.width = 60;
+  c.height = 60;
   c.classList.add('next-piece');
   nextContainer.appendChild(c);
   const ctx = c.getContext('2d');
-  ctx.scale(20, 20);
+  ctx.scale(15, 15);
   nextContexts.push(ctx);
+}
+
+const remoteNextContainer = document.getElementById('remote-next-container');
+const remoteNextContexts = [];
+for (let i = 0; i < 5; ++i) {
+  const c = document.createElement('canvas');
+  c.width = 60;
+  c.height = 60;
+  c.classList.add('next-piece');
+  remoteNextContainer.appendChild(c);
+  const ctx = c.getContext('2d');
+  ctx.scale(15, 15);
+  remoteNextContexts.push(ctx);
 }
 
 const colors = [
@@ -43,6 +56,8 @@ const nextPieces = [];
 for (let i = 0; i < 5; ++i) {
   nextPieces.push(getRandomPiece());
 }
+
+let remoteNextPieces = [];
 
 function arenaSweep() {
   outer: for (let y = arena.length - 1; y > 0; --y) {
@@ -169,6 +184,17 @@ function drawNext() {
   });
 }
 
+function drawRemoteNext() {
+  remoteNextContexts.forEach((ctx, idx) => {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 4, 4);
+    const matrix = createPiece(remoteNextPieces[idx] || 'I');
+    const offX = ((4 - matrix[0].length) / 2) | 0;
+    const offY = ((4 - matrix.length) / 2) | 0;
+    drawMatrixOn(matrix, {x: offX, y: offY}, ctx);
+  });
+}
+
 function merge(arena, player) {
   player.matrix.forEach((row, y) => {
     row.forEach((value, x) => {
@@ -268,7 +294,7 @@ function update(time = 0) {
 
   draw();
   drawNext();
-  socket.emit('state', { arena, player });
+  socket.emit('state', { arena, player, nextPieces });
   requestAnimationFrame(update);
 }
 
@@ -299,8 +325,10 @@ socket.on('state', state => {
   remotePlayer.pos = state.player.pos;
   remotePlayer.matrix = state.player.matrix;
   remotePlayer.score = state.player.score;
+  remoteNextPieces = state.nextPieces || remoteNextPieces;
   updateRemoteScore();
   drawRemote();
+  drawRemoteNext();
 });
 
 playerReset();

--- a/style.css
+++ b/style.css
@@ -16,13 +16,20 @@ canvas {
   border: 2px solid #fff;
 }
 
-#next-container {
+.next-container {
   position: absolute;
   top: 50px;
-  left: calc(100% + 10px);
   display: flex;
   flex-direction: column;
   gap: 5px;
+}
+
+#next-container {
+  right: calc(100% + 10px);
+}
+
+#remote-next-container {
+  left: calc(100% + 10px);
 }
 
 .next-piece {


### PR DESCRIPTION
## Summary
- add next piece panel for remote player
- reposition next panel to avoid overlap with boards and shrink piece size
- transmit next piece queue over the network

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494c71f86883218d17aceba4838222