### PR TITLE
Implement quick drop on ArrowUp

### DIFF
--- a/main.js
+++ b/main.js
@@ -230,6 +230,18 @@ function playerDrop() {
   dropCounter = 0;
 }
 
+function playerHardDrop() {
+  while (!collide(arena, player)) {
+    player.pos.y++;
+  }
+  player.pos.y--;
+  merge(arena, player);
+  playerReset();
+  arenaSweep();
+  updateScore();
+  dropCounter = 0;
+}
+
 function playerMove(dir) {
   player.pos.x += dir;
   if (collide(arena, player)) {
@@ -272,6 +284,8 @@ document.addEventListener('keydown', event => {
     playerMove(1);
   } else if (event.key === 'ArrowDown') {
     playerDrop();
+  } else if (event.key === 'ArrowUp') {
+    playerHardDrop();
   } else if (event.key === 'q') {
     playerRotate(-1);
   } else if (event.key === 'w') {


### PR DESCRIPTION
## Summary
- add playerHardDrop to instantly drop the active piece
- trigger quick drop when pressing the ArrowUp key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684950a956148321bb6cc1272e422010