### PR TITLE
Improve game end feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ A simple Tetris implementation that runs directly in your browser.
 - **Arrow Left / Right**: Move the piece sideways
 - **Arrow Down**: Drop the piece faster
 - **q / w**: Rotate the piece
+- **Enter**: Restart after a game over
 
 

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <canvas id="remote-tetris" width="240" height="400"></canvas>
     <div id="remote-next-container" class="next-container"></div>
   </div>
+  <div id="message" class="message"></div>
   <script src="/socket.io/socket.io.js"></script>
   <script src="main.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -44,3 +44,18 @@ canvas {
   color: #fff;
   font-family: monospace;
 }
+
+.message {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  font-family: monospace;
+  font-size: 3rem;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 20px 40px;
+  border: 2px solid #fff;
+  display: none;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- show a central overlay for game results
- freeze gameplay on loss and allow restart with `Enter`
- notify the local player when the opponent loses
- document the new restart key

## Testing
- `npm test`
- `npm start` *(fails before installing dependencies)*
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684a51cbe4fc8321ac53a986d354a718