### PR TITLE
fix: resolve Docker Alpine Linux Rollup dependency issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.git
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+dist
+build
+*.log
+.DS_Store
+package-lock.json
+client/package-lock.json 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-# Copy package files for all workspaces
-COPY package*.json ./
-COPY client/package*.json ./client/
+# Copy package files only (package-lock.json is excluded by .dockerignore)
+COPY package.json ./
+COPY client/package.json ./client/
 
-# Install dependencies for all workspaces
+# Install all dependencies: root + workspaces
 RUN npm install
+RUN npm install --workspaces
 
 # Copy client source and build
 COPY client/ ./client/


### PR DESCRIPTION
- Add .dockerignore to exclude host-dependent package-lock.json
- Update Dockerfile to generate fresh dependencies in Docker environment
- Eliminate host environment dependency for consistent Docker builds
- Fix @rollup/rollup-linux-x64-musl module resolution error

This resolves the build failure where Rollup platform-specific binaries were not properly resolved in Alpine Linux Docker environment.